### PR TITLE
アソシエーション変更1

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,12 @@ Things you may want to cover:
 | ------ | ---------- | ------------------------------ |
 | user   | references | null: false, foreign_key: true |
 | item   | references | null: false, foreign_key: true |
-|        |            |                                |
+
 
 ### Association
 - belongs_to :item
 - belongs_to :user
+- has_one :living_place
 
 ## living_place テーブル
 
@@ -85,4 +86,5 @@ Things you may want to cover:
 | phone_number  | string     | null: false                    |
 
 ### Association
-has_one :buyer
+belongs_to :buyer
+

--- a/README.md
+++ b/README.md
@@ -35,26 +35,30 @@ Things you may want to cover:
 | first_name      | string | null: false |
 | last_name_kana  | string | null: false |
 | first_name_kana | string | null: false |
-| email           | string | null: false |
 | birthday        | date   | null: false |
 
 ### Association
 
 - has_many :items
-- belongs_to:buyer
+- has_many :buyers
 
 ## items テーブル
 
-| Column              | Type    | Options     |
-| ------------------- | ------- | ----------- |
-| name                | string  | null: false |
-| price               | integer | null: false |
-| product_description | text    | null: false |
-|                     |         |             |
+| Column              | Type       | Options                        |
+| ------------------- | ---------- | ------------------------------ |
+| user                | references | null: false, foreign_key: true |
+| name                | string     | null: false                    |
+| price               | integer    | null: false                    |
+| product_description | text       | null: false                    |
+| category_id         | integer    | null: false                    |
+| product_status_id   | integer    | null: false                    |
+| postage_id          | integer    | null: false                    |
+| ship_from_id        | integer    | null: false                    |
+| date_of_shipment_id | integer    | null: false                    |
 
 ### Association
 
-- belong_to :users
+- belong_to :user
 - has_one :buyer
 
 ## article テーブル
@@ -64,14 +68,14 @@ Things you may want to cover:
 | category_id         | integer | null: false |
 | product_status_id   | integer | null: false |
 | postage_id          | integer | null: false |
-| ship_from \_id      | integer | null: false |
+| ship_from_id        | integer | null: false |
 | date_of_shipment_id | integer | null: false |
 
 ### Association
 
 has_one :item
 
-## buyer テーブル
+## buyers テーブル
 
 | Column | Type       | Options                        |
 | ------ | ---------- | ------------------------------ |
@@ -84,17 +88,18 @@ has_one :item
 - belongs_to :item
 - belongs_to :user
 
-## living place テーブル
+## living_place テーブル
 
-| Column        | Type    | Options     |
-| ------------- | ------- | ----------- |
-| postcode      | string  | null: false |
-| prefecture_id | integer | null: false |
-| city          | string  | null: false |
-| block         | string  | null: false |
-| building      | string  |             |
-| phone_number  | string  | null: false |
-|               |         |             |
+| Column        | Type       | Options                        |
+| ------------- | ---------- | ------------------------------ |
+| buyer         | references | null: false, foreign_key: true |
+| postcode      | string     | null: false                    |
+| prefecture_id | integer    | null: false                    |
+| city          | string     | null: false                    |
+| block         | string     | null: false                    |
+| building      | string     |                                |
+| phone_number  | string     | null: false                    |
+
 
 ### Association
 

--- a/README.md
+++ b/README.md
@@ -57,23 +57,8 @@ Things you may want to cover:
 | date_of_shipment_id | integer    | null: false                    |
 
 ### Association
-
 - belong_to :user
 - has_one :buyer
-
-## article テーブル
-
-| Column              | Type    | Options     |
-| ------------------- | ------- | ----------- |
-| category_id         | integer | null: false |
-| product_status_id   | integer | null: false |
-| postage_id          | integer | null: false |
-| ship_from_id        | integer | null: false |
-| date_of_shipment_id | integer | null: false |
-
-### Association
-
-has_one :item
 
 ## buyers テーブル
 
@@ -84,7 +69,6 @@ has_one :item
 |        |            |                                |
 
 ### Association
-
 - belongs_to :item
 - belongs_to :user
 
@@ -100,7 +84,5 @@ has_one :item
 | building      | string     |                                |
 | phone_number  | string     | null: false                    |
 
-
 ### Association
-
 has_one :buyer

--- a/README.md
+++ b/README.md
@@ -5,20 +5,97 @@ application up and running.
 
 Things you may want to cover:
 
-* Ruby version
+- Ruby version
 
-* System dependencies
+- System dependencies
 
-* Configuration
+- Configuration
 
-* Database creation
+- Database creation
 
-* Database initialization
+- Database initialization
 
-* How to run the test suite
+- How to run the test suite
 
-* Services (job queues, cache servers, search engines, etc.)
+- Services (job queues, cache servers, search engines, etc.)
 
-* Deployment instructions
+- Deployment instructions
 
-* ...
+- ...
+
+# テーブル設計
+
+## users テーブル
+
+| Column          | Type   | Options     |
+| --------------- | ------ | ----------- |
+| nickname        | string | null: false |
+| email           | string | null: false |
+| last_name       | string | null: false |
+| first_name      | string | null: false |
+| last_name_kana  | string | null: false |
+| first_name_kana | string | null: false |
+| email           | string | null: false |
+| birthday        | date   | null: false |
+
+### Association
+
+- has_many :items
+- belongs_to:buyer
+
+## items テーブル
+
+| Column              | Type    | Options     |
+| ------------------- | ------- | ----------- |
+| name                | string  | null: false |
+| price               | integer | null: false |
+| product_description | text    | null: false |
+|                     |         |             |
+
+### Association
+
+- belong_to :users
+- has_one :buyer
+
+## article テーブル
+
+| Column              | Type    | Options     |
+| ------------------- | ------- | ----------- |
+| category_id         | integer | null: false |
+| product_status_id   | integer | null: false |
+| postage_id          | integer | null: false |
+| ship_from \_id      | integer | null: false |
+| date_of_shipment_id | integer | null: false |
+
+### Association
+
+has_one :item
+
+## buyer テーブル
+
+| Column | Type       | Options                        |
+| ------ | ---------- | ------------------------------ |
+| user   | references | null: false, foreign_key: true |
+| item   | references | null: false, foreign_key: true |
+|        |            |                                |
+
+### Association
+
+- belongs_to :item
+- belongs_to :user
+
+## living place テーブル
+
+| Column        | Type    | Options     |
+| ------------- | ------- | ----------- |
+| postcode      | string  | null: false |
+| prefecture_id | integer | null: false |
+| city          | string  | null: false |
+| block         | string  | null: false |
+| building      | string  |             |
+| phone_number  | string  | null: false |
+|               |         |             |
+
+### Association
+
+has_one :buyer


### PR DESCRIPTION
#what
フリガナを保存するカラムを用意
誕生日を保存するカラムをdate型に変更

itemテーブル
nickname カラムの削除
item_name   のnameに変更
商品説明及び金額を保存するカラムを追加

buyerテーブル
references型で設計される場合、カラム名の_idを削除

buyerテーブルの
| user_id       | references | null: false, foreign_key: true |
| items_id      | references | null: false, foreign_key: true |
を削除
郵便番号をstring型に変更
| prefecture_id | string   integer型に変更
| building      | string     | null: false                    |のnull: falseを削除
 phone_number  | integer    |string型に変更
has_many :items　belongs_toに変更
belongs_toであれば、テーブル名は単数形
配送先住所テーブルとのアソシエーションを追記
itemsテーブルにitemsテーブルに対するアソシエーションを削除

articleテーブルを制作

#way
アソシエーション変更１回目
ER図です
https://gyazo.com/0dac60080d0dc3a175b0f91dc07b55e6
